### PR TITLE
共有の参照先を持つ変数を返すとその値を変更した際に、別の箇所にも影響が出てしまうため、コピーを渡すように変更

### DIFF
--- a/src/hooks/useMemos.js
+++ b/src/hooks/useMemos.js
@@ -16,7 +16,7 @@ export const useMemos = () => {
 
     memos.value.push(newMemo)
 
-    return newMemo
+    return { ...newMemo }
   }
 
   const removeMemo = (targetId) => {


### PR DESCRIPTION
## やったこと
共有の参照先を持つ変数を返すとその値を変更した際に、別の箇所にも影響が出てしまうため、コピーを渡すように変更